### PR TITLE
Fix bindless path in `pbr.wgsl`

### DIFF
--- a/libs/bevy_layered_materials/src/render/pbr.wgsl
+++ b/libs/bevy_layered_materials/src/render/pbr.wgsl
@@ -47,6 +47,13 @@
 #import bevy_pbr::decal::forward::get_forward_decal_info
 #endif
 
+#ifdef BINDLESS
+#import bevy_pbr::{
+    pbr_bindings::material_indices,
+    mesh_bindings::mesh,
+};
+#endif
+
 @fragment
 fn fragment(
 #ifdef MESHLET_MESH_MATERIAL_PASS
@@ -77,8 +84,12 @@ fn fragment(
 #endif
 
     // generate a PbrInput struct from the StandardMaterial bindings
+#ifdef BINDLESS
+    let slot = mesh[in.instance_index].material_and_lightmap_bind_group_slot & 0xffffu;
+    var pbr_input = pbr_input_from_standard_material(in, is_front, pbr_bindings::material_array[material_indices[slot].material].layer_index);
+#else
     var pbr_input = pbr_input_from_standard_material(in, is_front, pbr_bindings::material.layer_index);
-
+#endif
     // alpha discard
     pbr_input.material.base_color = alpha_discard(pbr_input.material, pbr_input.material.base_color);
 


### PR DESCRIPTION
In the case where `BINDLESS` is defined, `pbr_bindings.wgsl` does not define `material`, but `material_indices`:
```rust
#ifdef BINDLESS
struct StandardMaterialBindings {
  // stuff
}

@group(#{MATERIAL_BIND_GROUP}) @binding(0) var<storage> material_indices: array<StandardMaterialBindings>;
@group(#{MATERIAL_BIND_GROUP}) @binding(10) var<storage> material_array: array<StandardMaterial>;

#else   // BINDLESS

@group(#{MATERIAL_BIND_GROUP}) @binding(0) var<uniform> material: StandardMaterial;
// more stuff
#endif
```

That means that the line
```rust
var pbr_input = pbr_input_from_standard_material(in, is_front, pbr_bindings::material.layer_index);
```
cannot work, as `material` doesn't exist. Instead, let's take a look at https://github.com/bevyengine/bevy/blob/main/assets/shaders/extended_material_bindless.wgsl to see how this is meant to be handled:
```rust
#ifdef BINDLESS
    // Fetch the material slot. We'll use this in turn to fetch the bindless
    // indices from `example_extended_material_indices`.
    let slot = mesh[in.instance_index].material_and_lightmap_bind_group_slot & 0xffffu;
#endif  // BINDLESS
```
and further down
```rust
let uv_transform = material_array[material_indices[slot].material].uv_transform;
```